### PR TITLE
[Taken in] Fixing bug where Air-O2 measurement command startAirO2ContinuousMeasurement() did not use scale offsets.

### DIFF
--- a/src/SensirionI2cSfmSf06.cpp
+++ b/src/SensirionI2cSfmSf06.cpp
@@ -80,6 +80,18 @@ int16_t SensirionI2cSfmSf06::startAirContinuousMeasurement() {
     return localError;
 }
 
+int16_t
+SensirionI2cSfmSf06::startAirO2ContinuousMeasurement(uint16_t volumeFraction) {
+    int16_t localError = 0;
+    localError = readScaleOffsetUnit(START_AIR_O2_CONTINUOUS_MEASUREMENT_CMD_ID,
+                                     _flowScaleFactor, _flowOffset, _flowUnit);
+    if (localError != NO_ERROR) {
+        return localError;
+    }
+    localError = llstartAirO2ContinuousMeasurement(volumeFraction);
+    return localError;
+}
+
 int16_t SensirionI2cSfmSf06::startN2OContinuousMeasurement() {
     int16_t localError = 0;
     localError = readScaleOffsetUnit(START_N2O_CONTINUOUS_MEASUREMENT_CMD_ID,
@@ -216,8 +228,8 @@ int16_t SensirionI2cSfmSf06::llstartCO2ContinuousMeasurement() {
     return localError;
 }
 
-int16_t
-SensirionI2cSfmSf06::startAirO2ContinuousMeasurement(uint16_t volumeFraction) {
+int16_t SensirionI2cSfmSf06::llstartAirO2ContinuousMeasurement(
+    uint16_t volumeFraction) {
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
     SensirionI2CTxFrame txFrame =

--- a/src/SensirionI2cSfmSf06.h
+++ b/src/SensirionI2cSfmSf06.h
@@ -103,6 +103,15 @@ class SensirionI2cSfmSf06 {
     /**
      * @brief Start measurement and update internal state
      *
+     * @param[in] volumeFraction Volume fraction of O₂ in ‰.
+     *
+     * @return error_code 0 on success, an error code otherwise.
+     */
+    int16_t startAirO2ContinuousMeasurement(uint16_t volumeFraction);
+
+    /**
+     * @brief Start measurement and update internal state
+     *
      * Start NO2 measurement and readout the corresponding scale factor from the
      * sensor
      *
@@ -294,7 +303,7 @@ class SensirionI2cSfmSf06 {
      *
      * @return error_code 0 on success, an error code otherwise.
      */
-    int16_t startAirO2ContinuousMeasurement(uint16_t volumeFraction);
+    int16_t llstartAirO2ContinuousMeasurement(uint16_t volumeFraction);
 
     /**
      * @brief Start continuous measurement of N₂O / O₂ mixture.


### PR DESCRIPTION
As brought up by an issue I posted earlier, there is an issue with the `startAirO2ContinuousMeasurement()` command where it does not grab the proper scale-offsets upon calling. As such, you had to call another measurement method(such as `startO2ContinuousMeasurement()`) to properly get the scale-factors before running the AirO2 measurement. I have done a quick edit to fix this, by properly calling the `readScaleOffsetUnit()` function within `startAirO2ContinuousMeasurement()` . I have adhered to the abstraction in the code by creating a new method `llstartAirO2ContinuousMeasurement()`, which performs the same function of reading from the sensor as `startAirO2ContinuousMeasurement()` currently does. I then call this function in `startAirO2ContinuousMeasurement()` after obtaining the scale factors using the `readScaleOffsetUnit()` method. I've tested this and it works for my device (with no reason to suspect it will not work on others). I have also appropriately formatted this using clang-format. Please let me know if this is a bad pull-request! It's my first one in a long time.